### PR TITLE
Remove `kernelspec` from frontmatter of tutorials

### DIFF
--- a/docs/tutorials/example-febrl.qmd
+++ b/docs/tutorials/example-febrl.qmd
@@ -2,11 +2,6 @@
 title: Linking the FEBRL datasets
 description: Using PPRL locally to link two well-known datasets
 format: html
-jupyter:
-    kernelspec:
-        name: "pprl"
-        language: "python"
-        display_name: "pprl"
 ---
 
 This tutorial shows how the package can be used locally to match the

--- a/docs/tutorials/example-verknupfung.qmd
+++ b/docs/tutorials/example-verknupfung.qmd
@@ -1,11 +1,6 @@
 ---
 title: "Exploring a simple linkage example"
 format: html
-jupyter:
-    kernelspec:
-        name: "pprl"
-        language: "python"
-        display_name: "pprl"
 ---
 
 The Python package implements the Bloom filter linkage method ([Schnell et al., 2009](https://bmcmedinformdecismak.biomedcentral.com/articles/10.1186/1472-6947-9-41)), and can also implement pretrained Hash embeddings ([Miranda et al., 2022](https://arxiv.org/abs/2212.09255)), if a suitable large, pre-matched corpus of data is available.

--- a/docs/tutorials/run-through.qmd
+++ b/docs/tutorials/run-through.qmd
@@ -1,11 +1,6 @@
 ---
 title: "Embedder API run-through"
 format: html
-jupyter:
-    kernelspec:
-        name: "pprl"
-        language: "python"
-        display_name: "pprl"
 ---
 
 This article shows the main classes, methods and functionality of the Embedder


### PR DESCRIPTION
First hurdle in fixing #39 achieved by #40. New issue is the kernel specification.