### PR TITLE
28 enforce consistency on missing value handling in featurespy

### DIFF
--- a/docs/tutorials/run-through.qmd
+++ b/docs/tutorials/run-through.qmd
@@ -16,7 +16,7 @@ First, we'll import a few modules, including:
 
 ```{python}
 import os
-
+import numpy as np
 import pandas as pd
 
 from pprl import EmbeddedDataFrame, Embedder, config
@@ -32,10 +32,11 @@ don't have to have the same structure or field names.
 df1 = pd.DataFrame(
     dict(
         id=[1,2,3],
-        forename=["Henry", "Sally", "Ina"],
-        surname = ["Tull", "Brown", "Lawrey"],
-        dob=["1/1/2001", "2/1/2001", "4/10/1995"],
-        gender=["male", "Male", "Female"],
+        forename=["Henry", "Henry", "Ina"],
+        surname = ["Tull", "Tull", "Lawrey"],
+        dob=["", "", "4/10/1995"],
+        gender=["Male", "Male", "Female"],
+        county=["", np.NaN, "County Durham"]
     )
 )
 
@@ -45,6 +46,7 @@ df2 = pd.DataFrame(
         full_name=["Harry Tull", "Sali Brown", "Ina Laurie"],
         date_of_birth=["2/1/2001", "2/1/2001", "4/11/1995"],
         sex=["M", "M", "F"],
+        county=["Rutland", "Powys", "Durham"]
     )
 )
 ```
@@ -64,6 +66,7 @@ feature_factory = dict(
     name=feat.gen_name_features,
     dob=feat.gen_dateofbirth_features,
     sex=feat.gen_sex_features,
+    misc=feat.gen_misc_features
 )
 
 ff_args = dict(name={}, sex={}, dob={})
@@ -91,10 +94,10 @@ contribute to the embedding.
 
 ```{python}
 edf1 = embedder.embed(
-    df1, colspec=dict(forename="name", surname="name", dob="dob", gender="sex")
+    df1, colspec=dict(forename="name", surname="name", dob="dob", gender="sex", county="misc")
 )
 edf2 = embedder.embed(
-    df2, colspec=dict(full_name="name", date_of_birth="dob", sex="sex")
+    df2, colspec=dict(full_name="name", date_of_birth="dob", sex="sex", county="misc")
 )
 
 print(edf1)

--- a/docs/tutorials/run-through.qmd
+++ b/docs/tutorials/run-through.qmd
@@ -32,9 +32,9 @@ don't have to have the same structure or field names.
 df1 = pd.DataFrame(
     dict(
         id=[1,2,3],
-        forename=["Henry", "Henry", "Ina"],
-        surname = ["Tull", "Tull", "Lawrey"],
-        dob=["", "", "4/10/1995"],
+        forename=["Henry", "Sally", "Ina"],
+        surname = ["Tull", "Brown", "Lawrey"],
+        dob=["", "2/1/2001", "4/10/1995"],
         gender=["Male", "Male", "Female"],
         county=["", np.NaN, "County Durham"]
     )

--- a/docs/tutorials/run-through.qmd
+++ b/docs/tutorials/run-through.qmd
@@ -35,7 +35,7 @@ df1 = pd.DataFrame(
         forename=["Henry", "Sally", "Ina"],
         surname = ["Tull", "Brown", "Lawrey"],
         dob=["", "2/1/2001", "4/10/1995"],
-        gender=["Male", "Male", "Female"],
+        gender=["male", "Male", "Female"],
         county=["", np.NaN, "County Durham"]
     )
 )

--- a/src/pprl/embedder/features.py
+++ b/src/pprl/embedder/features.py
@@ -251,7 +251,7 @@ def gen_dateofbirth_features(
     dob: pd.Series,
     dayfirst: bool = True,
     yearfirst: bool = False,
-    default: list[str] = ["day<01>", "month<01>", "year<2050>"],
+    default: list[str] = [],
 ) -> pd.Series:
     """Generate labelled date features from a series of dates of birth.
 

--- a/src/pprl/embedder/features.py
+++ b/src/pprl/embedder/features.py
@@ -314,6 +314,7 @@ def gen_misc_features(field: pd.Series, label: None | str | Hashable = None) -> 
 
     _field = (
         field.copy()
+        .replace("", "no_data", regex=False)
         .fillna("no_data")
         .astype("str")
         .str.casefold()  # make everything lowercase

--- a/test/embedder/test_features.py
+++ b/test/embedder/test_features.py
@@ -434,7 +434,7 @@ def test_gen_misc_features(fields, label):
     assert features.dtype == list
 
     for feature, field in zip(features, fields):
-        if field is None or (isinstance(field, float) and pd.isna(field)):
+        if field is None or field == "" or (isinstance(field, float) and pd.isna(field)):
             assert feature == ""
         else:
             assert feature == [f"{label}<{str(field).casefold()}>"]


### PR DESCRIPTION
fixes #28 

Pull request to:

- Set the default value for dates that cannot be parsed to an empty list for gen_dateofbirth_features
- Treat null values and empty strings in the same way for gen_misc_features
- Update the tutorial to show these changes in action
- Update the test for empty string values
